### PR TITLE
Fix options page status display

### DIFF
--- a/options.js
+++ b/options.js
@@ -9,7 +9,11 @@ function saveOptions() {
   chrome.storage.sync.set({ domain }, () => {
     const status = document.getElementById('status');
     status.textContent = 'Settings saved.';
-    setTimeout(() => { status.textContent = ''; }, 2000);
+    status.classList.add('show');
+    setTimeout(() => {
+      status.textContent = '';
+      status.classList.remove('show');
+    }, 2000);
   });
 }
 


### PR DESCRIPTION
## Summary
- fix status message visibility by toggling CSS class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fe80d5494832cbf4a36eef1cb6642