### PR TITLE
Add CodeQL workflow and fix options.js syntax

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches for which pull requests will be analyzed.
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: npm ci --prefer-offline
+
+    - name: Run tests
+      run: npm test --if-present
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/options.js
+++ b/options.js
@@ -15,6 +15,7 @@ function saveOptions() {
       status.classList.remove('show');
     }, 2000);
   });
+}
 
 function restoreOptions() {
   chrome.storage.sync.get('domain', (items) => {


### PR DESCRIPTION
## Summary
- add GitHub CodeQL workflow that installs deps, runs tests, and analyzes JavaScript
- fix missing closing brace in options.js so tests pass

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840088a0688832cb56953c230a512d1