### PR TITLE
Add Norwegian and Swedish localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Open in Kasm Chrome Extension
 
-This extension adds a context menu item "Open in Kasm" when you right-click on any page, link, or selected text. Clicking it will open the URL in Kasm.
+This extension adds context menu items under **Open In** when you right-click on any page, link or selected text. You can choose to open the URL in Kasm in a new tab or a new window.
+
+The extension is localized and will automatically use your browser's language when available. It currently includes translations for English, Spanish, Norwegian, and Swedish.
 
 ## Installation
 
@@ -16,7 +18,7 @@ This extension adds a context menu item "Open in Kasm" when you right-click on a
 
 ## Usage
 
-Right-click on a page, link, or selected text and choose "Open in Kasm".
+Right-click on a page, link, or selected text and choose **Open In**. Then pick **New Tab** or **New Window** to launch the page through your configured Kasm instance.
 
 ## Development
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": { "message": "Open in Kasm" },
+  "settingsSaved": { "message": "Settings saved." },
+  "kasmDomain": { "message": "Kasm Domain" },
+  "save": { "message": "Save" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "Open In" },
+  "openInNewTab": { "message": "New Tab" },
+  "openInNewWindow": { "message": "New Window" },
+  "disclaimer": { "message": "Disclaimer: This is an independent project." }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": { "message": "Abrir en Kasm" },
+  "settingsSaved": { "message": "Configuraci\u00f3n guardada." },
+  "kasmDomain": { "message": "Dominio de Kasm" },
+  "save": { "message": "Guardar" },
+  "info": { "message": "Informaci\u00f3n" },
+  "openIn": { "message": "Abrir En" },
+  "openInNewTab": { "message": "Nueva Pesta\u00f1a" },
+  "openInNewWindow": { "message": "Nueva Ventana" },
+  "disclaimer": { "message": "Descargo de responsabilidad: Este es un proyecto independiente." }
+}

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": { "message": "\u00c5pne i Kasm" },
+  "settingsSaved": { "message": "Innstillinger lagret." },
+  "kasmDomain": { "message": "Kasm-domene" },
+  "save": { "message": "Lagre" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "\u00c5pne i" },
+  "openInNewTab": { "message": "Nytt faneark" },
+  "openInNewWindow": { "message": "Nytt vindu" },
+  "disclaimer": { "message": "Ansvarsfraskrivelse: Dette er et uavhengig prosjekt." }
+}

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,0 +1,11 @@
+{
+  "extensionName": { "message": "\u00d6ppna i Kasm" },
+  "settingsSaved": { "message": "Inst\u00e4llningar sparade." },
+  "kasmDomain": { "message": "Kasm-dom\u00e4n" },
+  "save": { "message": "Spara" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "\u00d6ppna i" },
+  "openInNewTab": { "message": "Ny flik" },
+  "openInNewWindow": { "message": "Nytt f\u00f6nster" },
+  "disclaimer": { "message": "Ansvarsfriskrivning: Detta \u00e4r ett oberoende projekt." }
+}

--- a/background.js
+++ b/background.js
@@ -1,12 +1,26 @@
 chrome.runtime.onInstalled.addListener(() => {
+  const contexts = ["link", "page", "selection"];
   chrome.contextMenus.create({
     id: "open_in_kasm",
-    title: "Open in Kasm",
-    contexts: ["link", "page", "selection"]
+    title: chrome.i18n.getMessage("openIn"),
+    contexts
+  });
+  chrome.contextMenus.create({
+    id: "open_in_kasm_tab",
+    parentId: "open_in_kasm",
+    title: chrome.i18n.getMessage("openInNewTab"),
+    contexts
+  });
+  chrome.contextMenus.create({
+    id: "open_in_kasm_window",
+    parentId: "open_in_kasm",
+    title: chrome.i18n.getMessage("openInNewWindow"),
+    contexts
   });
 });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+chrome.contextMenus.onClicked.addListener((info) => {
+  if (!info.menuItemId.startsWith('open_in_kasm_')) return;
   let url = info.linkUrl || info.pageUrl || info.selectionText;
   if (info.selectionText) {
     url = info.selectionText.startsWith('http') ? info.selectionText : '';
@@ -14,6 +28,10 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (!url) return;
   chrome.storage.sync.get({ domain: 'https://kasm.example.com' }, (items) => {
     const kasmUrl = `${items.domain}/#/go?kasm_url=${encodeURIComponent(url)}`;
-    chrome.tabs.create({ url: kasmUrl });
+    if (info.menuItemId === 'open_in_kasm_window') {
+      chrome.windows.create({ url: kasmUrl });
+    } else {
+      chrome.tabs.create({ url: kasmUrl });
+    }
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Open in Kasm",
-  "version": "1.0",
-  "description": "Adds a context menu item to open pages in Kasm.",
+  "version": "1.2",
+  "description": "Adds context menu items to open pages in Kasm.",
   "permissions": [
     "contextMenus",
     "storage"
@@ -10,6 +10,7 @@
   "background": {
     "service_worker": "background.js"
   },
+  "default_locale": "en",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/options.html
+++ b/options.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Open in Kasm Settings</title>
+  <title>__MSG_extensionName__</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
@@ -107,18 +107,18 @@
   <div class="container">
     <div class="header">
       <img src="icons/icon48.png" alt="Icon" class="header-icon" />
-      <h1>Open in Kasm</h1>
+      <h1>__MSG_extensionName__</h1>
     </div>
     <div class="field">
-      <label for="domain">Kasm Domain</label>
+      <label for="domain">__MSG_kasmDomain__</label>
       <input type="text" id="domain" placeholder="https://kasm.example.com" />
     </div>
     <div class="button-group">
-      <button id="save">Save</button>
-      <button id="info" class="info-btn">Info</button>
+      <button id="save">__MSG_save__</button>
+      <button id="info" class="info-btn">__MSG_info__</button>
     </div>
     <p id="status"></p>
-    <p class="footer">Disclaimer: This is an independent project.</p>
+    <p class="footer">__MSG_disclaimer__</p>
   </div>
   <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,4 +1,7 @@
-document.addEventListener('DOMContentLoaded', restoreOptions);
+document.addEventListener('DOMContentLoaded', () => {
+  localize();
+  restoreOptions();
+});
 document.getElementById('save').addEventListener('click', saveOptions);
 document.getElementById('info').addEventListener('click', () => {
   window.open('https://kasmweb.com/docs/latest/guide/browser_isolation.html#go-url');
@@ -8,7 +11,7 @@ function saveOptions() {
   const domain = document.getElementById('domain').value;
   chrome.storage.sync.set({ domain }, () => {
     const status = document.getElementById('status');
-    status.textContent = 'Settings saved.';
+    status.textContent = chrome.i18n.getMessage('settingsSaved');
     status.classList.add('show');
     setTimeout(() => {
       status.textContent = '';
@@ -26,5 +29,13 @@ function restoreOptions() {
       input.value = ''; // leave placeholder visible
     }
   });
+}
+
+function localize() {
+  document.querySelector('h1').textContent = chrome.i18n.getMessage('extensionName');
+  document.querySelector('label[for="domain"]').textContent = chrome.i18n.getMessage('kasmDomain');
+  document.getElementById('save').textContent = chrome.i18n.getMessage('save');
+  document.getElementById('info').textContent = chrome.i18n.getMessage('info');
+  document.querySelector('.footer').textContent = chrome.i18n.getMessage('disclaimer');
 }
 


### PR DESCRIPTION
## Summary
- include nb and sv translations for UI text
- bump extension version to 1.2
- document available languages in the README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684013453e08832ca2f91c63c5b80292