### PR TITLE
Add localization settings and new languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Open in Kasm Chrome Extension
 
-This extension adds a context menu item "Open in Kasm" when you right-click on any page, link, or selected text. Clicking it will open the URL in Kasm.
+This extension adds context menu items under **Open In** when you right-click on any page, link or selected text. You can choose to open the URL in Kasm in a new tab or a new window.
+
+The extension is localized and will automatically use your browser's language when available. It currently includes translations for English, Spanish, Norwegian, Swedish, German, and French. You can also choose your preferred language on the options page.
 
 ## Installation
 
@@ -12,11 +14,11 @@ This extension adds a context menu item "Open in Kasm" when you right-click on a
 
 1. Open `chrome://extensions` and locate **Open in Kasm**.
 2. Click **Details** and then **Extension options** to open the options page.
-3. Enter the URL of your Kasm instance (e.g. `https://kasm.example.com`) and click **Save**.
+3. Enter the URL of your Kasm instance (e.g. `https://kasm.example.com`), select your preferred language, and click **Save**.
 
 ## Usage
 
-Right-click on a page, link, or selected text and choose "Open in Kasm".
+Right-click on a page, link, or selected text and choose **Open In**. Then pick **New Tab** or **New Window** to launch the page through your configured Kasm instance.
 
 ## Development
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "In Kasm \u00f6ffnen" },
+  "settingsSaved": { "message": "Einstellungen gespeichert." },
+  "kasmDomain": { "message": "Kasm-Domain" },
+  "save": { "message": "Speichern" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "\u00d6ffnen in" },
+  "openInNewTab": { "message": "Neuer Tab" },
+  "openInNewWindow": { "message": "Neues Fenster" },
+  "disclaimer": { "message": "Haftungsausschluss: Dies ist ein unabh\u00e4ngiges Projekt." },
+  "language": { "message": "Sprache" }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "Open in Kasm" },
+  "settingsSaved": { "message": "Settings saved." },
+  "kasmDomain": { "message": "Kasm Domain" },
+  "save": { "message": "Save" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "Open In" },
+  "openInNewTab": { "message": "New Tab" },
+  "openInNewWindow": { "message": "New Window" },
+  "disclaimer": { "message": "Disclaimer: This is an independent project." },
+  "language": { "message": "Language" }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "Abrir en Kasm" },
+  "settingsSaved": { "message": "Configuraci\u00f3n guardada." },
+  "kasmDomain": { "message": "Dominio de Kasm" },
+  "save": { "message": "Guardar" },
+  "info": { "message": "Informaci\u00f3n" },
+  "openIn": { "message": "Abrir En" },
+  "openInNewTab": { "message": "Nueva Pesta\u00f1a" },
+  "openInNewWindow": { "message": "Nueva Ventana" },
+  "disclaimer": { "message": "Descargo de responsabilidad: Este es un proyecto independiente." },
+  "language": { "message": "Idioma" }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "Ouvrir dans Kasm" },
+  "settingsSaved": { "message": "Param\u00e8tres enregistr\u00e9s." },
+  "kasmDomain": { "message": "Domaine Kasm" },
+  "save": { "message": "Enregistrer" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "Ouvrir dans" },
+  "openInNewTab": { "message": "Nouvel onglet" },
+  "openInNewWindow": { "message": "Nouvelle fen\u00eatre" },
+  "disclaimer": { "message": "Avertissement : Ceci est un projet ind\u00e9pendant." },
+  "language": { "message": "Langue" }
+}

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "\u00c5pne i Kasm" },
+  "settingsSaved": { "message": "Innstillinger lagret." },
+  "kasmDomain": { "message": "Kasm-domene" },
+  "save": { "message": "Lagre" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "\u00c5pne i" },
+  "openInNewTab": { "message": "Nytt faneark" },
+  "openInNewWindow": { "message": "Nytt vindu" },
+  "disclaimer": { "message": "Ansvarsfraskrivelse: Dette er et uavhengig prosjekt." },
+  "language": { "message": "Spr\u00e5k" }
+}

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,0 +1,12 @@
+{
+  "extensionName": { "message": "\u00d6ppna i Kasm" },
+  "settingsSaved": { "message": "Inst\u00e4llningar sparade." },
+  "kasmDomain": { "message": "Kasm-dom\u00e4n" },
+  "save": { "message": "Spara" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "\u00d6ppna i" },
+  "openInNewTab": { "message": "Ny flik" },
+  "openInNewWindow": { "message": "Nytt f\u00f6nster" },
+  "disclaimer": { "message": "Ansvarsfriskrivning: Detta \u00e4r ett oberoende projekt." },
+  "language": { "message": "Spr\u00e5k" }
+}

--- a/background.js
+++ b/background.js
@@ -1,12 +1,46 @@
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.create({
-    id: "open_in_kasm",
-    title: "Open in Kasm",
-    contexts: ["link", "page", "selection"]
+async function createMenus() {
+  const { language } = await chrome.storage.sync.get('language');
+  const lang = language || chrome.i18n.getUILanguage().split('-')[0];
+  let msgs;
+  try {
+    const res = await fetch(chrome.runtime.getURL(`_locales/${lang}/messages.json`));
+    msgs = await res.json();
+  } catch (e) {
+    const res = await fetch(chrome.runtime.getURL('_locales/en/messages.json'));
+    msgs = await res.json();
+  }
+  const contexts = ["link", "page", "selection"];
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: "open_in_kasm",
+      title: msgs.openIn.message,
+      contexts
+    });
+    chrome.contextMenus.create({
+      id: "open_in_kasm_tab",
+      parentId: "open_in_kasm",
+      title: msgs.openInNewTab.message,
+      contexts
+    });
+    chrome.contextMenus.create({
+      id: "open_in_kasm_window",
+      parentId: "open_in_kasm",
+      title: msgs.openInNewWindow.message,
+      contexts
+    });
   });
+}
+
+chrome.runtime.onInstalled.addListener(createMenus);
+chrome.runtime.onStartup.addListener(createMenus);
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes.language) {
+    createMenus();
+  }
 });
 
-chrome.contextMenus.onClicked.addListener((info, tab) => {
+chrome.contextMenus.onClicked.addListener((info) => {
+  if (!info.menuItemId.startsWith('open_in_kasm_')) return;
   let url = info.linkUrl || info.pageUrl || info.selectionText;
   if (info.selectionText) {
     url = info.selectionText.startsWith('http') ? info.selectionText : '';
@@ -14,6 +48,10 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (!url) return;
   chrome.storage.sync.get({ domain: 'https://kasm.example.com' }, (items) => {
     const kasmUrl = `${items.domain}/#/go?kasm_url=${encodeURIComponent(url)}`;
-    chrome.tabs.create({ url: kasmUrl });
+    if (info.menuItemId === 'open_in_kasm_window') {
+      chrome.windows.create({ url: kasmUrl });
+    } else {
+      chrome.tabs.create({ url: kasmUrl });
+    }
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Open in Kasm",
-  "version": "1.0",
-  "description": "Adds a context menu item to open pages in Kasm.",
+  "version": "1.3",
+  "description": "Adds context menu items to open pages in Kasm.",
   "permissions": [
     "contextMenus",
     "storage"
@@ -10,6 +10,7 @@
   "background": {
     "service_worker": "background.js"
   },
+  "default_locale": "en",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/options.html
+++ b/options.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Open in Kasm Settings</title>
+  <title>__MSG_extensionName__</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
@@ -107,18 +107,29 @@
   <div class="container">
     <div class="header">
       <img src="icons/icon48.png" alt="Icon" class="header-icon" />
-      <h1>Open in Kasm</h1>
+      <h1>__MSG_extensionName__</h1>
     </div>
     <div class="field">
-      <label for="domain">Kasm Domain</label>
+      <label for="domain">__MSG_kasmDomain__</label>
       <input type="text" id="domain" placeholder="https://kasm.example.com" />
     </div>
+    <div class="field">
+      <label for="language">__MSG_language__</label>
+      <select id="language">
+        <option value="en">English</option>
+        <option value="es">Espa\u00f1ol</option>
+        <option value="nb">Norsk</option>
+        <option value="sv">Svenska</option>
+        <option value="de">Deutsch</option>
+        <option value="fr">Fran\u00e7ais</option>
+      </select>
+    </div>
     <div class="button-group">
-      <button id="save">Save</button>
-      <button id="info" class="info-btn">Info</button>
+      <button id="save">__MSG_save__</button>
+      <button id="info" class="info-btn">__MSG_info__</button>
     </div>
     <p id="status"></p>
-    <p class="footer">Disclaimer: This is an independent project.</p>
+    <p class="footer">__MSG_disclaimer__</p>
   </div>
   <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,4 +1,8 @@
-document.addEventListener('DOMContentLoaded', restoreOptions);
+document.addEventListener('DOMContentLoaded', () => {
+  restoreOptions();
+  document.getElementById('language').addEventListener('change', localize);
+  localize();
+});
 document.getElementById('save').addEventListener('click', saveOptions);
 document.getElementById('info').addEventListener('click', () => {
   window.open('https://kasmweb.com/docs/latest/guide/browser_isolation.html#go-url');
@@ -6,9 +10,10 @@ document.getElementById('info').addEventListener('click', () => {
 
 function saveOptions() {
   const domain = document.getElementById('domain').value;
-  chrome.storage.sync.set({ domain }, () => {
+  const language = document.getElementById('language').value;
+  chrome.storage.sync.set({ domain, language }, () => {
     const status = document.getElementById('status');
-    status.textContent = 'Settings saved.';
+    status.textContent = chrome.i18n.getMessage('settingsSaved');
     status.classList.add('show');
     setTimeout(() => {
       status.textContent = '';
@@ -18,13 +23,43 @@ function saveOptions() {
 }
 
 function restoreOptions() {
-  chrome.storage.sync.get('domain', (items) => {
+  chrome.storage.sync.get(['domain', 'language'], (items) => {
     const input = document.getElementById('domain');
     if (items.domain) {
       input.value = items.domain;
     } else {
       input.value = ''; // leave placeholder visible
     }
-  });
+    if (items.language) {
+      document.getElementById('language').value = items.language;
+    }
+    });
+}
+
+async function localize() {
+  const defaultLang = (typeof chrome !== 'undefined' && chrome.i18n && chrome.i18n.getUILanguage)
+    ? chrome.i18n.getUILanguage().split('-')[0]
+    : 'en';
+  const lang = document.getElementById('language').value || defaultLang;
+  try {
+    const res = await fetch(chrome.runtime.getURL(`_locales/${lang}/messages.json`));
+    const msgs = await res.json();
+    applyMessages(msgs);
+  } catch (e) {
+    if (lang !== 'en') {
+      const res = await fetch(chrome.runtime.getURL('_locales/en/messages.json'));
+      const msgs = await res.json();
+      applyMessages(msgs);
+    }
+  }
+}
+
+function applyMessages(msgs) {
+  document.querySelector('h1').textContent = msgs.extensionName.message;
+  document.querySelector('label[for="domain"]').textContent = msgs.kasmDomain.message;
+  document.querySelector('label[for="language"]').textContent = msgs.language.message;
+  document.getElementById('save').textContent = msgs.save.message;
+  document.getElementById('info').textContent = msgs.info.message;
+  document.querySelector('.footer').textContent = msgs.disclaimer.message;
 }
 

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -5,14 +5,17 @@ const { JSDOM } = require('jsdom');
 
 describe('restoreOptions', () => {
   test('populates domain input when value is stored', () => {
-    const html = `\n      <input id="domain">\n      <div id="status"></div>\n      <button id="save"></button>\n      <button id="info"></button>\n    `;
+    const html = `\n      <input id="domain">\n      <select id="language"></select>\n      <div id="status"></div>\n      <button id="save"></button>\n      <button id="info"></button>\n    `;
     const dom = new JSDOM(html);
 
     const chrome = {
       storage: {
         sync: {
-          get: jest.fn((key, cb) => cb({ domain: 'example.com' }))
+          get: jest.fn((keys, cb) => cb({ domain: 'example.com', language: 'es' }))
         }
+      },
+      runtime: {
+        getURL: (p) => path.join(__dirname, '..', p)
       }
     };
 


### PR DESCRIPTION
## Summary
- add language selector to options page
- implement dynamic localization logic in options page and background
- add German and French locales
- update other locale files with `language` string
- bump version to 1.3 and document languages in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684013453e08832ca2f91c63c5b80292