### PR TITLE
Add language selection and extra locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This extension adds context menu items under **Open In** when you right-click on any page, link or selected text. You can choose to open the URL in Kasm in a new tab or a new window.
 
-The extension is localized and will automatically use your browser's language when available. It currently includes translations for English, Spanish, Norwegian, and Swedish.
+The extension is localized and will automatically use your browser's language when available. It now includes translations for English, Spanish, Norwegian, Swedish, French and German. You can also choose a preferred language in the extension options.
 
 ## Installation
 
@@ -14,7 +14,8 @@ The extension is localized and will automatically use your browser's language wh
 
 1. Open `chrome://extensions` and locate **Open in Kasm**.
 2. Click **Details** and then **Extension options** to open the options page.
-3. Enter the URL of your Kasm instance (e.g. `https://kasm.example.com`) and click **Save**.
+3. Enter the URL of your Kasm instance (e.g. `https://kasm.example.com`).
+4. Choose your preferred language or leave **System Default** to follow your browser settings and click **Save**.
 
 ## Usage
 

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": { "message": "In Kasm öffnen" },
+  "settingsSaved": { "message": "Einstellungen gespeichert." },
+  "kasmDomain": { "message": "Kasm-Domain" },
+  "save": { "message": "Speichern" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "Öffnen in" },
+  "openInNewTab": { "message": "Neuer Tab" },
+  "openInNewWindow": { "message": "Neues Fenster" },
+  "disclaimer": { "message": "Haftungsausschluss: Dies ist ein unabhängiges Projekt." },
+  "language": { "message": "Sprache" },
+  "systemDefault": { "message": "Systemsprache" }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,11 +1,35 @@
 {
-  "extensionName": { "message": "Open in Kasm" },
-  "settingsSaved": { "message": "Settings saved." },
-  "kasmDomain": { "message": "Kasm Domain" },
-  "save": { "message": "Save" },
-  "info": { "message": "Info" },
-  "openIn": { "message": "Open In" },
-  "openInNewTab": { "message": "New Tab" },
-  "openInNewWindow": { "message": "New Window" },
-  "disclaimer": { "message": "Disclaimer: This is an independent project." }
+  "extensionName": {
+    "message": "Open in Kasm"
+  },
+  "settingsSaved": {
+    "message": "Settings saved."
+  },
+  "kasmDomain": {
+    "message": "Kasm Domain"
+  },
+  "save": {
+    "message": "Save"
+  },
+  "info": {
+    "message": "Info"
+  },
+  "openIn": {
+    "message": "Open In"
+  },
+  "openInNewTab": {
+    "message": "New Tab"
+  },
+  "openInNewWindow": {
+    "message": "New Window"
+  },
+  "disclaimer": {
+    "message": "Disclaimer: This is an independent project."
+  },
+  "language": {
+    "message": "Language"
+  },
+  "systemDefault": {
+    "message": "System Default"
+  }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,11 +1,35 @@
 {
-  "extensionName": { "message": "Abrir en Kasm" },
-  "settingsSaved": { "message": "Configuraci\u00f3n guardada." },
-  "kasmDomain": { "message": "Dominio de Kasm" },
-  "save": { "message": "Guardar" },
-  "info": { "message": "Informaci\u00f3n" },
-  "openIn": { "message": "Abrir En" },
-  "openInNewTab": { "message": "Nueva Pesta\u00f1a" },
-  "openInNewWindow": { "message": "Nueva Ventana" },
-  "disclaimer": { "message": "Descargo de responsabilidad: Este es un proyecto independiente." }
+  "extensionName": {
+    "message": "Abrir en Kasm"
+  },
+  "settingsSaved": {
+    "message": "Configuración guardada."
+  },
+  "kasmDomain": {
+    "message": "Dominio de Kasm"
+  },
+  "save": {
+    "message": "Guardar"
+  },
+  "info": {
+    "message": "Información"
+  },
+  "openIn": {
+    "message": "Abrir En"
+  },
+  "openInNewTab": {
+    "message": "Nueva Pestaña"
+  },
+  "openInNewWindow": {
+    "message": "Nueva Ventana"
+  },
+  "disclaimer": {
+    "message": "Descargo de responsabilidad: Este es un proyecto independiente."
+  },
+  "language": {
+    "message": "Idioma"
+  },
+  "systemDefault": {
+    "message": "Predeterminado del sistema"
+  }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,13 @@
+{
+  "extensionName": { "message": "Ouvrir dans Kasm" },
+  "settingsSaved": { "message": "Paramètres enregistrées." },
+  "kasmDomain": { "message": "Domaine Kasm" },
+  "save": { "message": "Enregistrer" },
+  "info": { "message": "Info" },
+  "openIn": { "message": "Ouvrir dans" },
+  "openInNewTab": { "message": "Nouvel onglet" },
+  "openInNewWindow": { "message": "Nouvelle fenêtre" },
+  "disclaimer": { "message": "Avertissement : Ceci est un projet indépendant." },
+  "language": { "message": "Langue" },
+  "systemDefault": { "message": "Langue du système" }
+}

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1,11 +1,35 @@
 {
-  "extensionName": { "message": "\u00c5pne i Kasm" },
-  "settingsSaved": { "message": "Innstillinger lagret." },
-  "kasmDomain": { "message": "Kasm-domene" },
-  "save": { "message": "Lagre" },
-  "info": { "message": "Info" },
-  "openIn": { "message": "\u00c5pne i" },
-  "openInNewTab": { "message": "Nytt faneark" },
-  "openInNewWindow": { "message": "Nytt vindu" },
-  "disclaimer": { "message": "Ansvarsfraskrivelse: Dette er et uavhengig prosjekt." }
+  "extensionName": {
+    "message": "Åpne i Kasm"
+  },
+  "settingsSaved": {
+    "message": "Innstillinger lagret."
+  },
+  "kasmDomain": {
+    "message": "Kasm-domene"
+  },
+  "save": {
+    "message": "Lagre"
+  },
+  "info": {
+    "message": "Info"
+  },
+  "openIn": {
+    "message": "Åpne i"
+  },
+  "openInNewTab": {
+    "message": "Nytt faneark"
+  },
+  "openInNewWindow": {
+    "message": "Nytt vindu"
+  },
+  "disclaimer": {
+    "message": "Ansvarsfraskrivelse: Dette er et uavhengig prosjekt."
+  },
+  "language": {
+    "message": "Språk"
+  },
+  "systemDefault": {
+    "message": "Systemstandard"
+  }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,11 +1,35 @@
 {
-  "extensionName": { "message": "\u00d6ppna i Kasm" },
-  "settingsSaved": { "message": "Inst\u00e4llningar sparade." },
-  "kasmDomain": { "message": "Kasm-dom\u00e4n" },
-  "save": { "message": "Spara" },
-  "info": { "message": "Info" },
-  "openIn": { "message": "\u00d6ppna i" },
-  "openInNewTab": { "message": "Ny flik" },
-  "openInNewWindow": { "message": "Nytt f\u00f6nster" },
-  "disclaimer": { "message": "Ansvarsfriskrivning: Detta \u00e4r ett oberoende projekt." }
+  "extensionName": {
+    "message": "Öppna i Kasm"
+  },
+  "settingsSaved": {
+    "message": "Inställningar sparade."
+  },
+  "kasmDomain": {
+    "message": "Kasm-domän"
+  },
+  "save": {
+    "message": "Spara"
+  },
+  "info": {
+    "message": "Info"
+  },
+  "openIn": {
+    "message": "Öppna i"
+  },
+  "openInNewTab": {
+    "message": "Ny flik"
+  },
+  "openInNewWindow": {
+    "message": "Nytt fönster"
+  },
+  "disclaimer": {
+    "message": "Ansvarsfriskrivning: Detta är ett oberoende projekt."
+  },
+  "language": {
+    "message": "Språk"
+  },
+  "systemDefault": {
+    "message": "Systemstandard"
+  }
 }

--- a/background.js
+++ b/background.js
@@ -1,22 +1,32 @@
-chrome.runtime.onInstalled.addListener(() => {
+function loadMessages(cb) {
+  chrome.storage.sync.get('language', (items) => {
+    const chosen = items.language && items.language !== 'system' ? items.language : chrome.i18n.getUILanguage().split('-')[0];
+    const url = chrome.runtime.getURL(`_locales/${chosen}/messages.json`);
+    fetch(url)
+      .then(r => r.json())
+      .then(cb)
+      .catch(() => fetch(chrome.runtime.getURL('_locales/en/messages.json')).then(r => r.json()).then(cb));
+  });
+}
+
+function createMenus(msgs) {
   const contexts = ["link", "page", "selection"];
-  chrome.contextMenus.create({
-    id: "open_in_kasm",
-    title: chrome.i18n.getMessage("openIn"),
-    contexts
-  });
-  chrome.contextMenus.create({
-    id: "open_in_kasm_tab",
-    parentId: "open_in_kasm",
-    title: chrome.i18n.getMessage("openInNewTab"),
-    contexts
-  });
-  chrome.contextMenus.create({
-    id: "open_in_kasm_window",
-    parentId: "open_in_kasm",
-    title: chrome.i18n.getMessage("openInNewWindow"),
-    contexts
-  });
+  chrome.contextMenus.create({ id: "open_in_kasm", title: msgs.openIn.message, contexts });
+  chrome.contextMenus.create({ id: "open_in_kasm_tab", parentId: "open_in_kasm", title: msgs.openInNewTab.message, contexts });
+  chrome.contextMenus.create({ id: "open_in_kasm_window", parentId: "open_in_kasm", title: msgs.openInNewWindow.message, contexts });
+}
+
+function setupMenus() {
+  chrome.contextMenus.removeAll(() => loadMessages(createMenus));
+}
+
+chrome.runtime.onInstalled.addListener(setupMenus);
+setupMenus();
+
+chrome.storage.onChanged.addListener((changes) => {
+  if (changes.language) {
+    setupMenus();
+  }
 });
 
 chrome.contextMenus.onClicked.addListener((info) => {

--- a/options.html
+++ b/options.html
@@ -56,6 +56,16 @@
       border-color: #007bff;
       outline: none;
     }
+    select {
+      width: 100%;
+      padding: 8px;
+      font-size: 1em;
+      margin-bottom: 16px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      box-sizing: border-box;
+      background: #fff;
+    }
     button {
       background-color: #007bff;
       color: #fff;
@@ -112,6 +122,18 @@
     <div class="field">
       <label for="domain">__MSG_kasmDomain__</label>
       <input type="text" id="domain" placeholder="https://kasm.example.com" />
+    </div>
+    <div class="field">
+      <label for="language">__MSG_language__</label>
+      <select id="language">
+        <option value="system">__MSG_systemDefault__</option>
+        <option value="en">English</option>
+        <option value="es">Español</option>
+        <option value="nb">Norsk</option>
+        <option value="sv">Svenska</option>
+        <option value="fr">Français</option>
+        <option value="de">Deutsch</option>
+      </select>
     </div>
     <div class="button-group">
       <button id="save">__MSG_save__</button>

--- a/options.js
+++ b/options.js
@@ -9,33 +9,51 @@ document.getElementById('info').addEventListener('click', () => {
 
 function saveOptions() {
   const domain = document.getElementById('domain').value;
-  chrome.storage.sync.set({ domain }, () => {
-    const status = document.getElementById('status');
-    status.textContent = chrome.i18n.getMessage('settingsSaved');
-    status.classList.add('show');
-    setTimeout(() => {
-      status.textContent = '';
-      status.classList.remove('show');
-    }, 2000);
+  const language = document.getElementById('language').value;
+  chrome.storage.sync.set({ domain, language }, () => {
+    loadMessages((msgs) => {
+      const status = document.getElementById('status');
+      status.textContent = msgs.settingsSaved.message;
+      status.classList.add('show');
+      setTimeout(() => {
+        status.textContent = '';
+        status.classList.remove('show');
+      }, 2000);
+    });
   });
 }
 
 function restoreOptions() {
-  chrome.storage.sync.get('domain', (items) => {
+  chrome.storage.sync.get(['domain', 'language'], (items) => {
     const input = document.getElementById('domain');
-    if (items.domain) {
-      input.value = items.domain;
-    } else {
-      input.value = ''; // leave placeholder visible
+    input.value = items.domain || '';
+    const langSelect = document.getElementById('language');
+    if (langSelect) {
+      langSelect.value = items.language || 'system';
     }
   });
 }
 
 function localize() {
-  document.querySelector('h1').textContent = chrome.i18n.getMessage('extensionName');
-  document.querySelector('label[for="domain"]').textContent = chrome.i18n.getMessage('kasmDomain');
-  document.getElementById('save').textContent = chrome.i18n.getMessage('save');
-  document.getElementById('info').textContent = chrome.i18n.getMessage('info');
-  document.querySelector('.footer').textContent = chrome.i18n.getMessage('disclaimer');
+  loadMessages((msgs) => {
+    document.querySelector('h1').textContent = msgs.extensionName.message;
+    document.querySelector('label[for="domain"]').textContent = msgs.kasmDomain.message;
+    document.querySelector('label[for="language"]').textContent = msgs.language.message;
+    document.querySelector('#language option[value="system"]').textContent = msgs.systemDefault.message;
+    document.getElementById('save').textContent = msgs.save.message;
+    document.getElementById('info').textContent = msgs.info.message;
+    document.querySelector('.footer').textContent = msgs.disclaimer.message;
+  });
+}
+
+function loadMessages(cb) {
+  chrome.storage.sync.get('language', (items) => {
+    const chosen = items.language && items.language !== 'system' ? items.language : chrome.i18n.getUILanguage().split('-')[0];
+    const url = chrome.runtime.getURL(`_locales/${chosen}/messages.json`);
+    fetch(url)
+      .then(r => r.json())
+      .then(cb)
+      .catch(() => fetch(chrome.runtime.getURL('_locales/en/messages.json')).then(r => r.json()).then(cb));
+  });
 }
 


### PR DESCRIPTION
## Summary
- add language dropdown to options page
- allow background and options scripts to load translations dynamically
- support French and German locales
- document new languages and preference setting

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401c9496c0832ca1aedd3ba257a467